### PR TITLE
Use ocp-index-options

### DIFF
--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -60,7 +60,7 @@
                           (file-name-sans-extension
                            (buffer-file-name))))))
     (format "%s %s %s -O %s %s"
-            ocp-index-path ocp-index-options cmd current-module arg)))
+            ocp-index-path cmd ocp-index-options current-module arg)))
 
 (defun ac-ocp-index-candidates ()
   (let* ((command     (ocp-index-cmd "complete" ac-prefix))


### PR DESCRIPTION
It looked like ocp-index-cmd was meant to use ocp-index-options, so I added that to use it.
