### PR TITLE
Complete keywords

### DIFF
--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -157,6 +157,7 @@ let interactive opts () =
             | LibIndex.Method _ -> Curses.WA.bold
             | LibIndex.Module | LibIndex.ModuleType -> Curses.WA.color_pair 1
             | LibIndex.Class | LibIndex.ClassType -> Curses.WA.color_pair 5
+            | LibIndex.Keyword -> Curses.WA.color_pair 7
           in
           let _set_tags =
             Format.set_tags true;

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -140,6 +140,7 @@ let common_opts : t Term.t =
       "c", `Constructs; "constructs", `Constructs;
       "m", `Modules; "modules", `Modules;
       "s", `Sigs; "sigs", `Sigs;
+      "k", `Keywords; "keywords", `Keywords;
     ] in
     let show =
       Arg.(value & opt (list (enum opts)) [] & info ["s";"show"]
@@ -147,8 +148,9 @@ let common_opts : t Term.t =
                    comma-separated list of `$(i,types)', `$(i,values)' and \
                    methods, `$(i,exceptions)', `$(i,constructs)' (record \
                    fields and sum type constructors), `$(i,modules)' and \
-                   classes, `$(i,sigs)' (module and class types). The default \
-                   is $(b,v,e,c,m)"
+                   classes, `$(i,sigs)' (module and class types), \
+                   `$(i,keywords)'. The default \
+                   is $(v,e,c,m,k)"
              ~docv:"LIST")
     in
     let hide =
@@ -162,9 +164,10 @@ let common_opts : t Term.t =
           let f key default = List.mem key show ||
                               default && not (List.mem key hide)
           in
-          let t,v,e,c,m,s =
+          let t,v,e,c,m,s,k =
             f `Types false, f `Values true, f `Exceptions true,
-            f `Constructs true, f `Modules true, f `Sigs false
+            f `Constructs true, f `Modules true, f `Sigs false,
+            f `Keyword true
           in
           LibIndex.(fun info -> match info.kind with
               | Type -> t
@@ -172,7 +175,8 @@ let common_opts : t Term.t =
               | Exception -> e
               | Field _ | Variant _ -> c
               | Module | Class -> m
-              | ModuleType | ClassType -> s))
+              | ModuleType | ClassType -> s
+              | Keyword -> k))
       $ show $ hide
     )
   in

--- a/src/indexOut.ml
+++ b/src/indexOut.ml
@@ -64,6 +64,7 @@ module IndexFormat = struct
         | Method _ -> "\027[1m"
         | Module | ModuleType -> "\027[31m"
         | Class | ClassType -> "\027[35m"
+        | Keyword -> "\027[32m"
       in
       Format.pp_print_as fmt 0 colorcode;
       Format.kfprintf (fun fmt -> Format.pp_print_as fmt 0 "\027[m") fmt fstr
@@ -100,6 +101,7 @@ module IndexFormat = struct
     | ModuleType -> Format.pp_print_string fmt "modtype"
     | Class -> Format.pp_print_string fmt "class"
     | ClassType -> Format.pp_print_string fmt "classtype"
+    | Keyword -> Format.pp_print_string fmt "keyword"
 
   let rec tydecl fmt =
     let open Outcometree in

--- a/src/indexPredefined.ml
+++ b/src/indexPredefined.ml
@@ -57,6 +57,17 @@ let mkexn name params doc = {
   file = Cmi "*built-in*";
 }
 
+let mkkwd name = {
+  path = [];
+  kind = Keyword;
+  name = name;
+  ty = None;
+  loc_sig = Location.none;
+  loc_impl = lazy Location.none;
+  doc = lazy None;
+  file = Cmi "*built-in*";
+}
+
 let var name = Otyp_var (false, name)
 
 let constr ?(params=[]) name =
@@ -164,4 +175,14 @@ let exceptions = [
      source code (file name, line number, column number).";
 ]
 
-let all = types @ variants @ exceptions
+let keywords = List.map mkkwd [
+    "and"; "as"; "assert"; "begin"; "class"; "constraint"; "do"; "done";
+    "downto"; "else"; "end"; "exception"; "external"; "false"; "for"; "fun";
+    "function"; "functor"; "if"; "in"; "include"; "inherit"; "inherit!";
+    "initializer"; "lazy"; "let"; "match"; "method"; "method!"; "module";
+    "mutable"; "new"; "object"; "of"; "open"; "open!"; "private"; "rec";
+    "sig"; "struct"; "then"; "to"; "true"; "try"; "type"; "val"; "val!";
+    "virtual"; "when"; "while"; "with";
+  ]
+
+let all = types @ variants @ exceptions @ keywords

--- a/src/indexPredefined.mli
+++ b/src/indexPredefined.mli
@@ -22,4 +22,6 @@ val variants: IndexTypes.info list
 
 val exceptions: IndexTypes.info list
 
+val keywords: IndexTypes.info list
+
 val all: IndexTypes.info list

--- a/src/indexTypes.ml
+++ b/src/indexTypes.ml
@@ -39,6 +39,7 @@ and kind =
   | Method of info
   | Module | ModuleType
   | Class | ClassType
+  | Keyword
 
 (** Lazy trie structure holding the info on all identifiers *)
 type t = (char, info) Trie.t

--- a/src/libIndex.mli
+++ b/src/libIndex.mli
@@ -44,6 +44,7 @@ and kind = IndexTypes.kind = private
   | Method of info
   | Module | ModuleType
   | Class | ClassType
+  | Keyword
 
 
 (** {2 Utility functions} *)


### PR DESCRIPTION
I use 'live' completion and got fed up of correcting when I type 'end' and the completion propose 'End_of_file'.
So here it is, the completion for keywords. I set it as on by default. It might not be what everybody want, but who wants to type 'function' or 'constraint' completely ?

Also, I did not encounter it yet, but I am not sure we want to have both "method" and "method!" in the keyword list.
