### PR TITLE
Added support for `completion-at-point`.

### DIFF
--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -44,7 +44,7 @@
   (require 'auto-complete nil t))
 
 (defcustom ocp-index-use-auto-complete ocp-index-has-auto-complete
-  "*If set, use `auto-complete' instead of `completion-at-point' for completion."
+  "*If set, use `auto-complete' for completion."
   :group 'ocp-index :type 'boolean)
 
 ;; auto-complete bug workaround (complete at EOF in text mode)


### PR DESCRIPTION
Added a customizable variable `ocp-index-use-auto-complete`. When set,
it gives the previous behaviour. If unset, the standard
`completion-at-point` mechanism is used. It is unset by default.

With this change, `auto-complete` package is no longer a requisite to
use `ocp-index.el`.
