### PR TITLE
Read include directories from .ocp-index

### DIFF
--- a/src/indexMain.ml
+++ b/src/indexMain.ml
@@ -19,6 +19,18 @@ open Cmdliner
 
 let common_opts = IndexOptions.common_opts ()
 
+let man = [
+  `S "COPYRIGHT";
+  `P "Ocp-index is written by Louis Gesbert <louis.gesbert@ocamlpro.com>, \
+      copyright OCamlPro 2013-2014, \
+      distributed under the terms of the LGPL v3 with linking exception. \
+      Full source available at $(i,https://github.com/OCamlPro/ocp-index)";
+  `S "BUGS";
+  `P "Bugs are tracked at $(i,https://github.com/OCamlPro/ocp-index/issues).";
+  `S "SEE ALSO";
+  `P "ocp-grep, ocp-browser";
+]
+
 let default_cmd =
   let man = [
     `S "DESCRIPTION";
@@ -27,7 +39,7 @@ let default_cmd =
         It gathers information from .cmi (like ocamlbrowser) and \
         .cmt/cmti files, including structure, location, type, and ocamldoc \
         comments when available."
-  ]
+  ] @ man
   in
   let doc = "Explore the interfaces of installed OCaml libraries." in
   Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_opts)),
@@ -58,18 +70,6 @@ let format_man =
         match, with the usual OCaml escapes plus the following sequences \
         interpreted:" ] @
   List.map (fun (k, s) -> `I (Printf.sprintf "$(b,%s)" k, s)) formats
-
-let man = [
-  `S "COPYRIGHT";
-  `P "Ocp-index is written by Louis Gesbert <louis.gesbert@ocamlpro.com>, \
-      copyright OCamlPro 2013-2014, \
-      distributed under the terms of the LGPL v3 with linking exception. \
-      Full source available at $(i,https://github.com/OCamlPro/ocp-index)";
-  `S "BUGS";
-  `P "Bugs are tracked at $(i,https://github.com/OCamlPro/ocp-index/issues).";
-  `S "SEE ALSO";
-  `P "ocp-grep, ocp-browser";
-]
 
 let complete_cmd =
   let man = [

--- a/src/indexMain.ml
+++ b/src/indexMain.ml
@@ -38,7 +38,12 @@ let default_cmd =
         OCaml, for command-line or integrated use (e.g. for completion). \
         It gathers information from .cmi (like ocamlbrowser) and \
         .cmt/cmti files, including structure, location, type, and ocamldoc \
-        comments when available."
+        comments when available.";
+    `S "USING AN .ocp-index FILE";
+    `P "Instead of passing a list of include directories using the \
+        $(b,`-I') option, it is also possible to pass them using a \
+        file named $(b, .ocp-index) placed at the root of the project \
+        directory.  It should be"
   ] @ man
   in
   let doc = "Explore the interfaces of installed OCaml libraries." in

--- a/src/indexMain.ml
+++ b/src/indexMain.ml
@@ -40,10 +40,17 @@ let default_cmd =
         .cmt/cmti files, including structure, location, type, and ocamldoc \
         comments when available.";
     `S "USING AN .ocp-index FILE";
-    `P "Instead of passing a list of include directories using the \
-        $(b,`-I') option, it is also possible to pass them using a \
-        file named $(b, .ocp-index) placed at the root of the project \
-        directory.  It should be"
+    `P "It is possible to specify some of the options for ocp-index in a file \
+        called $(b, .ocp-index) placed at the root of the project directory. \
+        Currently only the list of include directories can be specified in this way. \
+        Each line of the .ocp-index file should be of the form";
+    `P "I <dir>";
+    `P "where <dir> is the name of a directory where ocp-index should look for \
+        .cmt[i] files. Typically this way of specifying include directories would \
+        be used in conjunction with the $(b,--no-recursive) options in order to \
+        speed up directory scanning in those environments where the default \
+        method is not fast enough (e.g. Cygwin).  One can generate such a file by running";
+    `P "find . -name '*.cmt*' -exec dirname {} \\\\; | sort | uniq > .ocp-index"
   ] @ man
   in
   let doc = "Explore the interfaces of installed OCaml libraries." in

--- a/src/indexMain.ml
+++ b/src/indexMain.ml
@@ -44,13 +44,14 @@ let default_cmd =
         called $(b, .ocp-index) placed at the root of the project directory. \
         Currently only the list of include directories can be specified in this way. \
         Each line of the .ocp-index file should be of the form";
-    `P "I <dir>";
-    `P "where <dir> is the name of a directory where ocp-index should look for \
-        .cmt[i] files. Typically this way of specifying include directories would \
+    `P "I \"<dir>\"";
+    `P "where \"<dir>\" is the name of a directory (between double quotes) \
+        where ocp-index should look for .cmt[i] files. Typically this way \
+        of specifying include directories would \
         be used in conjunction with the $(b,--no-recursive) options in order to \
         speed up directory scanning in those environments where the default \
         method is not fast enough (e.g. Cygwin).  One can generate such a file by running";
-    `P "find . -name '*.cmt*' -exec dirname {} \\\\; | sort | uniq > .ocp-index"
+    `P "find . -name '*.cmt*' -exec dirname {} \\\\; | sort | uniq | sed 's/.*/I \"&\"/g' > .ocp-index"
   ] @ man
   in
   let doc = "Explore the interfaces of installed OCaml libraries." in

--- a/src/indexMisc.ml
+++ b/src/indexMisc.ml
@@ -112,12 +112,12 @@ let unique_subdirs ?(skip = fun _ -> false) dir_list =
 
 let read_all_lines path =
   let ic = open_in path in
-  let rec loop acc =
-    match input_line ic with
-    | l -> loop (l :: acc)
-    | exception End_of_file -> close_in ic; acc
+  let acc = ref [] in
+  let rec loop () =
+    let l = input_line ic in
+    acc := l :: !acc
   in
-  loop []
+  try loop (); assert false with End_of_file -> !acc
 
 (* - Project root finding - *)
 

--- a/src/indexMisc.ml
+++ b/src/indexMisc.ml
@@ -113,11 +113,12 @@ let unique_subdirs ?(skip = fun _ -> false) dir_list =
 let read_all_lines path =
   let ic = open_in path in
   let acc = ref [] in
-  let rec loop () =
-    let l = input_line ic in
-    acc := l :: !acc
-  in
-  try loop (); assert false with End_of_file -> !acc
+  try
+    while true do
+      acc := input_line ic :: !acc
+    done;
+    assert false
+  with End_of_file -> !acc
 
 (* - Project root finding - *)
 

--- a/src/indexMisc.ml
+++ b/src/indexMisc.ml
@@ -110,12 +110,20 @@ let unique_subdirs ?(skip = fun _ -> false) dir_list =
   in
   remove_dups (List.fold_left subdirs [] dir_list)
 
+let read_all_lines path =
+  let ic = open_in path in
+  let rec loop acc =
+    match input_line ic with
+    | l -> loop (l :: acc)
+    | exception End_of_file -> close_in ic; acc
+  in
+  loop []
 
 (* - Project root finding - *)
 
 let build_roots = (* by increasing order of priority *)
   [ "_darcs"; ".hg"; ".git";
-    "jengaroot.ml"; "omakeroot"; "_build"; "_obuild" ]
+    "jengaroot.ml"; "omakeroot"; "_build"; "_obuild"; ".ocp-index" ]
 
 let find_build_dir path =
   let ( / ) = Filename.concat in

--- a/src/indexMisc.mli
+++ b/src/indexMisc.mli
@@ -43,6 +43,8 @@ val parent_type: IndexTypes.info -> IndexTypes.info option
     If directory basename verifies [skip], it is not descended nor returned. *)
 val unique_subdirs: ?skip:(string -> bool) -> string list -> string list
 
+val read_all_lines: string -> string list
+
 (** An heuristic to guess where the root directory of the current project.
     Returns (project_root, build_dir) *)
 val project_root: ?path:string -> unit -> string option * string option

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -267,7 +267,7 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
             end
             else
               []
-        | _ -> []
+        | None -> []
       in
       dirs @ extra_dirs
     in

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -65,7 +65,7 @@ let default_filter = [ `V ; `E ; `C ; `M ; `K ]
 
 let filter_to_string l =
   let pp = function
-    | `V -> "v" | `E -> "b" | `C -> "c"
+    | `V -> "v" | `E -> "e" | `C -> "c"
     | `M -> "m" | `K -> "k" | `S -> "s"
     | `T -> "t"
   in

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -84,7 +84,7 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
       Arg.(value & flag & info ["no-opamlib"] ~doc);
     in
     let arg =
-      let doc = "OCaml directories to (recursively) load the libraries from." in
+      let doc = "OCaml directories to load the libraries from." in
       Arg.(value & opt_all (list string) [] & info ["I"] ~docv:"DIRS" ~doc)
     in
     let set_default no_stdlib no_opamlib includes =
@@ -98,6 +98,10 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
         try cmd_input_line "ocamlc -where" :: paths with Failure _ -> paths
     in
     Term.(pure set_default $ no_stdlib $ no_opamlib $ arg)
+  in
+  let no_recursive : bool Term.t =
+    let doc = "Do not traverse include directories recursively." in
+    Arg.(value & flag & info ["no-recursive"] ~doc)
   in
   let color : bool Term.t =
     let arg =
@@ -245,14 +249,22 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
     Arg.(value & opt (some filepos_converter) None
          & info ["context"] ~docv:"FILEPOS" ~doc)
   in
-  let lib_info ocamllib (_root,build) (opens,full_opens) context =
+  let lib_info ocamllib no_recursive (root,build) (opens,full_opens) context =
     let dirs = match build with
       | None -> ocamllib
       | Some d -> d :: ocamllib
     in
+    let dirs = match root with
+    | Some root when Sys.file_exists (Filename.concat root ".ocp-index") ->
+        dirs @ List.map (fun dir -> Filename.concat root dir) (IndexMisc.read_all_lines (Filename.concat root ".ocp-index"))
+    | _ -> dirs
+    in
     if dirs = [] then
       failwith "Failed to guess OCaml / opam lib dirs. Please use `-I'";
-    let dirs = LibIndex.Misc.unique_subdirs dirs in
+    IndexMisc.debug "Scanning directories... ";
+    let chrono = IndexMisc.timer () in
+    let dirs = if no_recursive then dirs else LibIndex.Misc.unique_subdirs dirs in
+    IndexMisc.debug "%.3fs\n%!" (chrono ());
     let info = LibIndex.load dirs in
     let info =
       List.fold_left (LibIndex.open_module ~cleanup_path:true) info opens
@@ -281,8 +293,8 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
   in
   Term.(
     pure
-      (fun ocamllib project_dirs opens color filter context ->
-         { lib_info = lib_info ocamllib project_dirs opens context;
+      (fun ocamllib no_recursive project_dirs opens color filter context ->
+         { lib_info = lib_info ocamllib no_recursive project_dirs opens context;
            color; filter; project_root = fst project_dirs })
-    $ ocamllib $ project_dirs $ open_modules $ color $ filter $ context
+    $ ocamllib $ no_recursive $ project_dirs $ open_modules $ color $ filter $ context
   )

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -84,7 +84,9 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
       Arg.(value & flag & info ["no-opamlib"] ~doc);
     in
     let arg =
-      let doc = "OCaml directories to load the libraries from." in
+      let doc = "OCaml directories to load the libraries from. \
+                 By default, the directories are traversed recursively. \
+                 This can be changed by passing the $(b,--no-recursive) option." in
       Arg.(value & opt_all (list string) [] & info ["I"] ~docv:"DIRS" ~doc)
     in
     let set_default no_stdlib no_opamlib includes =


### PR DESCRIPTION
See #76.

The behavior of `ocp-index` is left unchanged if no `.ocp-index` file is found in the tree.  If it is, then it used as project root and a list of include directories is read from it.  A new flag `--no-recursive` is added to complement this functionality.
