### PR TITLE
Fixes for 4.03.

### DIFF
--- a/src/indexOut.ml
+++ b/src/indexOut.ml
@@ -181,8 +181,8 @@ module IndexFormat = struct
         !Oprint.out_module_type fmt mtyp
     | Osig_type ({ otype_type },_) ->
         tydecl fmt otype_type
-    | Osig_value (_,ty,_) ->
-        !Oprint.out_type fmt ty
+    | Osig_value {oval_type} ->
+        !Oprint.out_type fmt oval_type
     | Osig_ellipsis ->
         Format.fprintf fmt "..."
 

--- a/src/indexPredefined.ml
+++ b/src/indexPredefined.ml
@@ -28,6 +28,7 @@ let mktype name ?(params=[]) ?(def=Otyp_abstract) doc = {
         otype_params  = List.map (fun v -> v,(true,true)) params;
         otype_type    = def;
         otype_private = Asttypes.Public;
+        otype_immediate = false ;
         otype_cstrs   = [] }, Orec_not));
   loc_sig = Lazy.from_val Location.none;
   loc_impl = Lazy.from_val Location.none;
@@ -46,6 +47,7 @@ let mkvariant name parent params = {
         otype_type    = (match params with [] -> Otyp_sum []
                                          | l  -> Otyp_tuple l);
         otype_private = Asttypes.Public;
+        otype_immediate = false ;
         otype_cstrs   = [] }, Orec_not));
   loc_sig = Lazy.from_val Location.none;
   loc_impl = Lazy.from_val Location.none;


### PR DESCRIPTION
This is the minimum to make it compiles. I'm not convinced putting immediate equals false everywhere is perfect, but at least it's usable. :)