### PR TITLE
Compatibility 4.01, 4.02, 4.03

### DIFF
--- a/opam
+++ b/opam
@@ -26,7 +26,7 @@ depends: [
 ]
 depopts: "lambda-term"
 conflicts: "lambda-term" {< "1.7"}
-available: [ocaml-version >= "4.01.0" & ocaml-version < "4.02"]
+available: [ocaml-version >= "4.01.0" ]
 messages: "For ocp-browser, please also install package lambda-term" {! lambda-term:installed}
 post-messages:
   "This package requires additional configuration for use in editors. Either install package 'user-setup', or manually:

--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ build: [
   [make]
 ]
 depends: [
-  "ocp-build" {>= "1.99.6-beta"}
+  "ocp-build" {>= "1.99.13-beta"}
   "ocp-indent" {>= "1.4.2"}
   "re"
   "cmdliner"

--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -11,11 +11,14 @@ let rec eq l1 l2 = match l1, l2 with
     {LibIndex. path = path2 ; name = name2 } :: t2 ->
       path1 = path2 && name1 = name2 && eq t1 t2
 
-(** Provide an association LibIndex.kind -> tag (= string) -> style
+(* * Provide an association LibIndex.kind -> tag (= string) -> style
     In order to encode styles in [Format.tag]. *)
 let kind_to_tag, tag_to_style, register_ressource =
   let h = Hashtbl.create 11 in
   let kind_to_tag = function
+#if OCAML_VERSION >= "4.03"
+    | LibIndex.OpenType
+#endif
     | LibIndex.Type -> "Type"
     | Value -> "Value"
     | Exception -> "Exception"
@@ -407,7 +410,7 @@ class virtual line_editor = object(self)
 end
 
 
-(** Strip one path level.
+(* * Strip one path level.
 
     Do the following transformation:
     "Foo.Bar."    -> "Foo."
@@ -553,7 +556,7 @@ let size (str : LTerm_text.t) =
   if fst str.(last) <> newline then incr rows ;
   {LTerm_geom. rows = !rows ; cols = !cols }
 
-(** The show box shows the result of a research.
+(* * The show box shows the result of a research.
 
     [content] is a list zipper positioned at the focused element.
     Left and right lists are elements before and after the focus.
@@ -785,7 +788,7 @@ let event_handler (cbox : #completion_box) (sbox:#show_box) options show_help =
       true
   | _ -> false
 
-(** Express the result as an event mapped on the content of the completion box.
+(* * Express the result as an event mapped on the content of the completion box.
 *)
 let show_completion show_box input =
   let zipper n l =

--- a/src/grepMain.ml
+++ b/src/grepMain.ml
@@ -14,12 +14,12 @@
 
 module Grep : sig
 
-  (** [ident path, filename, input channel, [line, column, length]]
+  (* * [ident path, filename, input channel, [line, column, length]]
       Finds occurence of given ident in an opened file.
       Results are in reverse order. *)
   val ident: string list -> string -> in_channel -> (int * int * int) list
 
-  (** [regex, filename, input channel, [line, column, length]]
+  (* * [regex, filename, input channel, [line, column, length]]
       Finds matches of a regexp in the strings of an opened ocaml file.
       Results are in reverse order. *)
   val strings_re: Re.re -> string -> in_channel -> (int * int * int) list
@@ -85,8 +85,14 @@ end = struct
         Filename.basename
           (try Filename.chop_extension f with Invalid_argument _ -> f)
       in
+#if OCAML_VERSION >= "4.03"
+      String.mapi (function 0 -> Char.uppercase_ascii | _ -> fun x -> x) s
+#elif OCAML_VERSION >= "4.02"
+      String.mapi (function 0 -> Char.uppercase | _ -> fun x -> x) s
+#else
       s.[0] <- Char.uppercase s.[0];
       s
+#endif
     in
     let f (curpath, lookfor, last_scope, acc) scope tok pos =
       let lookfor =
@@ -320,4 +326,3 @@ let () =
 (* idea: single utility to color parts of source with syntactic context:
    pattern, expr, type, topexpr, module, record ...
    Could be used for better completion, analysis etc.*)
-

--- a/src/indexMisc.ml
+++ b/src/indexMisc.ml
@@ -57,12 +57,28 @@ let string_to_key s =
 
 let key_to_string l =
   let rec aux n = function
+#if OCAML_VERSION >= "4.02"
+    | [] -> Bytes.create n
+#else
     | [] -> String.create n
+#endif
     | c::r ->
         let s = aux (n+1) r in
-        s.[n] <- if c = dot then '.' else c; s
+#if OCAML_VERSION >= "4.02"
+  Bytes.set s n
+#else
+  s.[n] <-
+#endif
+    (if c = dot then '.' else c);
+        s
   in
-  aux 0 l
+  let s = aux 0 l in
+#if OCAML_VERSION >= "4.02"
+    Bytes.to_string s
+#else
+    s
+#endif
+
 
 let modpath_to_key ?(enddot=true) path =
   List.fold_right (fun p acc ->
@@ -70,15 +86,12 @@ let modpath_to_key ?(enddot=true) path =
       string_to_key p @ acc) path []
 
 let key_to_modpath l =
-  let rec aux n = function
-    | [] -> if n > 0 then [String.create n] else []
-    | '\000'::r -> String.create n :: aux 0 r
-    | c::r ->
-        match aux (n+1) r with
-        | s::_ as p -> s.[n] <- c; p
-        | [] -> assert false
-  in
-  aux 0 l
+  let rec aux acc1 acc2 = function
+    | '\000'::r -> aux [] (acc1::acc2) r
+    | c::r -> aux (c::acc1) acc2 r
+    | [] -> if acc1 = [] then acc2 else acc1::acc2
+   in
+   List.rev_map (fun l -> key_to_string (List.rev l)) (aux [] [] l)
 
 let modpath_to_string path = String.concat "." path
 
@@ -86,6 +99,9 @@ let parent_type id =
   match id.IndexTypes.kind with
   | Field parent | Variant parent | Method parent -> Some parent
   | Type | Value | Exception | Module | ModuleType | Class
+#if OCAML_VERSION >= "4.02"
+  | OpenType
+#endif
   | ClassType | Keyword -> None
 
 

--- a/src/indexMisc.mli
+++ b/src/indexMisc.mli
@@ -39,15 +39,15 @@ val modpath_to_string: string list -> string
 (** Returns the parent type for field records, variants and methods *)
 val parent_type: IndexTypes.info -> IndexTypes.info option
 
-(** Returns the list of directories and all their recursive subdirectories.
+(* * Returns the list of directories and all their recursive subdirectories.
     If directory basename verifies [skip], it is not descended nor returned. *)
 val unique_subdirs: ?skip:(string -> bool) -> string list -> string list
 
-(** An heuristic to guess where the root directory of the current project.
+(* * An heuristic to guess where the root directory of the current project.
     Returns (project_root, build_dir) *)
 val project_root: ?path:string -> unit -> string option * string option
 
-(** Locates a build dir within a given directory, based on name ([_build],
+(* * Locates a build dir within a given directory, based on name ([_build],
     [_obuild], etc.) *)
 val find_build_dir: string -> string option
 

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -37,6 +37,9 @@ let filter opt info =
   let open LibIndex in
   let kinds = opt.filter in
   match info.kind with
+#if OCAML_VERSION >= "4.02"
+  | OpenType
+#endif
   | Type -> kinds.t
   | Value | Method _ -> kinds.v
   | Exception -> kinds.e

--- a/src/indexOut.ml
+++ b/src/indexOut.ml
@@ -64,6 +64,9 @@ module IndexFormat = struct
   let color =
     let f kind fstr fmt =
       let colorcode = match kind with
+#if OCAML_VERSION >= "4.02"
+        | OpenType
+#endif
         | Type -> "\027[36m"
         | Value -> "\027[1m"
         | Exception -> "\027[33m"
@@ -92,6 +95,9 @@ module IndexFormat = struct
 
   let kind ?(colorise = no_color) fmt id =
     match id.kind with
+#if OCAML_VERSION >= "4.02"
+    | OpenType -> Format.pp_print_string fmt "opentype"
+#endif
     | Type -> Format.pp_print_string fmt "type"
     | Value -> Format.pp_print_string fmt "val"
     | Exception -> Format.pp_print_string fmt "exception"
@@ -166,22 +172,44 @@ module IndexFormat = struct
     | Osig_class (_,_,_,ctyp,_)
     | Osig_class_type (_,_,_,ctyp,_) ->
         !Oprint.out_class_type fmt ctyp
+#if OCAML_VERSION >= "4.02"
+    | Osig_typext ({ oext_args = [] }, _) ->
+#else
     | Osig_exception (_,[]) ->
+#endif
         Format.pp_print_char fmt '-'
-    | Osig_exception (_,tylst) ->
+#if OCAML_VERSION >= "4.02"
+    | Osig_typext ({ oext_args }, _) ->
+#else
+    | Osig_exception (_,oext_args) ->
+#endif
         list ~paren:true
           !Oprint.out_type
           (fun fmt () ->
             Format.pp_print_char fmt ','; Format.pp_print_space fmt ())
           fmt
-          tylst
+          oext_args
     | Osig_modtype (_,mtyp)
     | Osig_module (_,mtyp,_) ->
         !Oprint.out_module_type fmt mtyp
+#if OCAML_VERSION >= "4.03"
+    | Osig_type ({ otype_type },_) ->
+        tydecl fmt otype_type
+    | Osig_value {oval_type} ->
+        !Oprint.out_type fmt oval_type
+    | Osig_ellipsis ->
+        Format.fprintf fmt "..."
+#elif OCAML_VERSION >= "4.02"
+    | Osig_type ({ otype_type },_) ->
+        tydecl fmt otype_type
+    | Osig_value (_,ty,_) ->
+        !Oprint.out_type fmt ty
+#else
     | Osig_type ((_,_,ty,_,_),_) ->
         tydecl fmt ty
     | Osig_value (_,ty,_) ->
         !Oprint.out_type fmt ty
+#endif
 
   let ty ?(colorise = no_color) fmt id =
     option_iter id.ty

--- a/src/indexPredefined.ml
+++ b/src/indexPredefined.ml
@@ -24,9 +24,20 @@ let mktype name ?(params=[]) ?(def=Otyp_abstract) doc = {
   kind = Type;
   name = name;
   ty = Some (Osig_type (
+#if OCAML_VERSION >= "4.02"
+      { otype_name    = name;
+        otype_params  = List.map (fun v -> v,(true,true)) params;
+        otype_type    = def;
+        otype_private = Asttypes.Public;
+#if OCAML_VERSION >= "4.03"
+      otype_immediate = false ;
+#endif
+        otype_cstrs   = [] }, Orec_not));
+#else
       (name,List.map (fun v -> v,(true,true)) params,def,Asttypes.Public,[]),
       Orec_not));
-  loc_sig = Lazy.from_val Location.none;
+#endif
+loc_sig = Lazy.from_val Location.none;
   loc_impl = Lazy.from_val Location.none;
   doc = Lazy.from_val (Some doc);
   file = Cmi "*built-in*";
@@ -37,11 +48,24 @@ let mkvariant name parent params = {
   orig_path = [];
   kind = Variant parent;
   name = name;
+#if OCAML_VERSION >= "4.02"
+  ty = Some (Osig_type (
+      { otype_name    = "";
+        otype_params  = [];
+        otype_type    = (match params with [] -> Otyp_sum []
+                                         | l  -> Otyp_tuple l);
+        otype_private = Asttypes.Public;
+#if OCAML_VERSION >= "4.03"
+        otype_immediate = false ;
+#endif
+        otype_cstrs   = [] }, Orec_not));
+#else
   ty = Some (Osig_type (("", [],
                          (match params with [] -> Otyp_sum []
                                           | l -> Otyp_tuple l),
                          Asttypes.Public, []),
                         Outcometree.Orec_not));
+#endif
   loc_sig = Lazy.from_val Location.none;
   loc_impl = Lazy.from_val Location.none;
   doc = Lazy.from_val None;
@@ -53,7 +77,17 @@ let mkexn name params doc = {
   orig_path = [];
   kind = Exception;
   name = name;
+#if OCAML_VERSION >= "4.02"
+  ty = Some (Osig_typext ({
+        oext_name        = name;
+        oext_type_name   = "exn";
+        oext_type_params = [];
+        oext_args        = params;
+        oext_ret_type    = None;
+        oext_private     = Asttypes.Public }, Oext_exception));
+#else
   ty = Some (Osig_exception (name,params));
+#endif
   loc_sig = Lazy.from_val Location.none;
   loc_impl = Lazy.from_val Location.none;
   doc = Lazy.from_val (Some doc);

--- a/src/indexTypes.ml
+++ b/src/indexTypes.ml
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** This module contains open types, for use within the library only. Its
+(* * This module contains open types, for use within the library only. Its
     interface should only be exported through closed types in LibIndex. *)
 
 (** Internal representation of types *)
@@ -36,6 +36,9 @@ type info = { path: string list;
 (** The kind of elements that can be stored in the trie *)
 and kind =
   | Type | Value | Exception
+#if OCAML_VERSION >= "4.02"
+  | OpenType
+#endif
   | Field of info | Variant of info
   | Method of info
   | Module | ModuleType
@@ -45,6 +48,6 @@ and kind =
 (** Lazy trie structure holding the info on all identifiers *)
 type t = (char, info) Trie.t
 
-(** Raised when cmi/cmt/cmti files can't be loaded. Probably a different
+(* * Raised when cmi/cmt/cmti files can't be loaded. Probably a different
     version of OCaml *)
 exception Bad_format of string

--- a/src/libIndex.mli
+++ b/src/libIndex.mli
@@ -12,7 +12,7 @@
 (*                                                                        *)
 (**************************************************************************)
 
-(** {1 ocp-index}
+(* * {1 ocp-index}
     Lightweight documentation extractor for installed OCaml libraries.
     This module contains the whole API. *)
 
@@ -25,7 +25,7 @@ type t
 type orig_file = IndexTypes.orig_file = private
     Cmt of string | Cmti of string | Cmi of string
 
-(** Raised when a file couldn't be loaded (generally due to a different
+(* * Raised when a file couldn't be loaded (generally due to a different
     compiler version) *)
 exception Bad_format of string
 
@@ -45,6 +45,9 @@ type info = IndexTypes.info = private {
 (** The kind of elements that can be stored in the trie *)
 and kind = IndexTypes.kind = private
   | Type | Value | Exception
+#if OCAML_VERSION >= "4.02"
+  | OpenType
+#endif
   | Field of info | Variant of info
   | Method of info
   | Module | ModuleType
@@ -55,7 +58,7 @@ and kind = IndexTypes.kind = private
 (** {2 Utility functions} *)
 
 module Misc: sig
-  (** Helper function, useful to lookup all subdirs of a given path before
+  (* * Helper function, useful to lookup all subdirs of a given path before
       calling [load] *)
   val unique_subdirs: ?skip:(string -> bool) -> string list -> string list
 end
@@ -63,7 +66,7 @@ end
 
 (** {2 Building} *)
 
-(** Build the trie from a list of include directories. They will be scanned for
+(* * Build the trie from a list of include directories. They will be scanned for
     [.cmi] and [.cmt] files to complete on module names, and the contents of
     these files will be lazily read whenever needed. *)
 val load: string list -> t
@@ -71,16 +74,16 @@ val load: string list -> t
 (** Load a single file into a trie *)
 val add_file: t -> string -> t
 
-(** Consider the module at the given path as opened, i.e. rebind its contents at
+(* * Consider the module at the given path as opened, i.e. rebind its contents at
     the root of the trie. If [cleanup_path], also change its contents to refer
     to the new path. *)
 val open_module: ?cleanup_path:bool -> t -> string list -> t
 
-(** Same as [open_module], but tries to open even the elements that are not in
+(* * Same as [open_module], but tries to open even the elements that are not in
     the external interface (this needs a cmt to be present) *)
 val fully_open_module: ?cleanup_path:bool -> t -> string list -> t
 
-(** [alias t origin alias] binds at [alias] the contents found at [origin]. If
+(* * [alias t origin alias] binds at [alias] the contents found at [origin]. If
     [~cleanup_path] is set, also change its contents to refer to the new
     path. *)
 val alias: ?cleanup_path:bool -> t -> string list -> string list -> t
@@ -93,12 +96,12 @@ val all: t -> info list
 (** Lookup an identifier in a trie (eg. [option] or [List.map]) *)
 val get: t -> string -> info
 
-(** Same as [get], but returns all existing bindings instead of only one. There
+(* * Same as [get], but returns all existing bindings instead of only one. There
     can consistently be several if they are of different kinds (eg. a type
     and a value...) *)
 val get_all: t -> string -> info list
 
-(** Lookup identifiers starting with the given string. Completion stops at
+(* * Lookup identifiers starting with the given string. Completion stops at
     module boundaries (it wont unfold contents of modules) *)
 val complete: t -> ?filter:(info -> bool) -> string -> info list
 

--- a/src/ocp-index.ocp
+++ b/src/ocp-index.ocp
@@ -1,28 +1,47 @@
 comp += [ "-g" "-w" "+1..39-4-9-37-40" ]
 
+if ocaml_version >= "4.02" then {
+   comp += [ "-safe-string" ]
+}
+
 begin library "ocp-index-lib"
   sort = false
   files = [ "trie.ml"
-            "indexTypes.ml" "indexMisc.ml" "indexOut.ml" "indexPredefined"
-            "indexBuild.ml" "libIndex.ml" "indexScope.ml" ]
+              "indexTypes.ml" (pp = "ocp-pp")
+              "indexMisc.ml" (pp = "ocp-pp")
+              "indexOut.mli"
+              "indexOut.ml" (pp = "ocp-pp")
+              "indexPredefined.mli"
+              "indexPredefined.ml" (pp = "ocp-pp")
+              "indexBuild.mli"
+              "indexBuild.ml" (pp = "ocp-pp")
+              "libIndex.ml" (pp = "ocp-pp")
+              "indexScope.ml" ]
   requires = [ "compiler-libs" "compiler-libs.common"
                "ocp-indent.lexer" "ocp-indent.utils" ]
 end
 
 begin program "ocp-index"
   sort = false
-  files = [ "indexOptions.ml" "indexMain.ml" ]
+        files = [
+        "indexOptions.mli"
+        "indexOptions.ml" (pp = "ocp-pp")
+          "indexMain.ml" ]
   requires = [ "ocp-index-lib" "unix" "cmdliner" ]
 end
 
 begin program "ocp-grep"
   sort = false
-  files = [ "grepMain.ml" ]
+  files = [ "grepMain.ml" (pp = "ocp-pp") ]
   requires = [ "unix" "cmdliner" "ocp-index-lib" "re" "re.posix" ]
 end
 
 begin program "ocp-browser"
   sort = false
-  files = [ "indexOptions.ml" "browserMain.ml" ]
+        files = [
+        "indexOptions.mli"
+        "indexOptions.ml" (pp = "ocp-pp")
+          "browserMain.ml" (pp = "ocp-pp")
+                ]
   requires = [ "ocp-index-lib" "unix" "cmdliner" "lambda-term" ]
 end


### PR DESCRIPTION
This branch uses `ocp-pp` to provide different codes for different versions of OCaml. 

Version of ocp-pp 1.99.16-beta compatible with 4.03.0 is now available on OPAM.