### PR TITLE
Move 'alt+h' advice in ocp-browser man page

### DIFF
--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -873,11 +873,12 @@ let run options () =
 
 let main_term : unit Cmdliner.Term.t * Cmdliner.Term.info =
   let open Cmdliner in
-  let doc = "Interactively completes and prints documentation. See Alt+h for help." in
+  let doc = "Interactively completes and prints documentation." in
+  let man = [`S "DESCRIPTION"; `P "See alt+h for help."] in
   Term.(pure run
         $ IndexOptions.common_opts ~default_filter:[`T;`V;`E;`C;`M;`S;`K] ()
         $ pure ()),
-  Term.info "ocp-browser" ~doc
+  Term.info "ocp-browser" ~doc ~man
 
 let () =
   match Cmdliner.Term.eval main_term


### PR DESCRIPTION
This commit moves the advice 'See alt+h for help' from the NAME section
to a new DESCRIPTION section in the man page for ocp-browser.

Often users will skim the man page and not notice the helpful advice in
the NAME section.
