### PR TITLE
Adapt ocp-index to eldoc.

### DIFF
--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -425,7 +425,7 @@ and greps in any OCaml source files from there. "
     (insert str)
     (let ((fill-column 1000))
       (fill-paragraph nil))
-    (buffer-substring (point-min) (point-max))))
+    (buffer-string)))
 
 (defun ocp-index-eldoc-function ()
   (condition-case nil


### PR DESCRIPTION
Eldoc is a emacs-maintained piece of code that displays information related to the thing at point (like C-c C-t in caml-types.el, but automatically).

This PR just adapts ocp-index.el to elget.