### PR TITLE
Improve eldoc support + add ivy support.

### DIFF
--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -110,10 +110,11 @@ the type is printed in the echo area)."
       ((current-module (upcase-initials
                         (file-name-nondirectory
                          (file-name-sans-extension (buffer-file-name)))))
-       (cmd (list* cmd ocp-index-options
+       (cmd (list* cmd
                    "--full-open" current-module
                    "--context" ":"
-                   args)))
+                   (append (split-string ocp-index-options)
+                           args))))
     (when ocp-index-debug
       (message "%s" (mapconcat
                      (lambda (s) (format "%S" s))

--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -49,6 +49,10 @@
   "*If set, use `auto-complete' for completion."
   :group 'ocp-index :type 'boolean)
 
+(defcustom ocp-index-use-eldoc nil
+  "*If set, use `eldoc-mode'."
+  :group 'ocp-index :type 'boolean)
+
 ;; auto-complete bug workaround (complete at EOF in text mode)
 (defun ocp-index-enable-ac-workaround ()
   (defun ac-menu-delete ()
@@ -441,13 +445,15 @@ and greps in any OCaml source files from there. "
   (cond (ocp-index-mode
          (add-function :before-until (local 'eldoc-documentation-function)
                        #'ocp-index-eldoc-function)
-         (eldoc-mode 1)
+         (when ocp-index-use-eldoc
+           (eldoc-mode 1))
          (ocp-index-setup-completion))
         (t
          (remove-function (local 'eldoc-documentation-function)
                           #'ocp-index-eldoc-function)
-         (cl-letf (((symbol-function 'message) #'ignore))
-           (eldoc-mode -1))
+         (when ocp-index-use-eldoc
+           (cl-letf (((symbol-function 'message) #'ignore))
+             (eldoc-mode -1)))
          (when ocp-index-use-auto-complete (auto-complete-mode -1)))))
 
 (add-hook 'tuareg-mode-hook 'ocp-index-mode t)

--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -416,13 +416,11 @@ and greps in any OCaml source files from there. "
   (ocp-index-setup-completion-at-point))
 
 ;; eldoc
-(defvar ocp-index-last-result nil)
 (defun display-message-or-buffer-tostring (msg &rest _)
-  (setq ocp-index-last-result
-        (let ((result (ocp-index-join-string msg)))
-          (if (string-match "No definition found\\|keyword\\.*" result)
-              ""
-            result))))
+  (let ((result (ocp-index-join-string msg)))
+    (if (string-match "No definition found\\|keyword\\.*" result)
+        ""
+      result)))
 
 (defun ocp-index-join-string (str)
   (with-temp-buffer

--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -76,7 +76,7 @@ the type is printed in the echo area)."
       (while (looking-back "\\<\\([A-Z][a-zA-Z0-9_']*\.\\)*[a-zA-Z0-9_']*"
                            (line-beginning-position) nil)
         (goto-char (match-beginning 0)))
-      (when (looking-at "[a-zA-Z0-9_'.]*[a-zA-Z0-9_']")
+      (when (looking-at "[a-zA-Z0-9_'.]+")
         (cons (match-beginning 0) (match-end 0))))))
 
 (defun ocp-index-completion-prefix-start ()

--- a/tools/ocp-index.el
+++ b/tools/ocp-index.el
@@ -417,17 +417,9 @@ and greps in any OCaml source files from there. "
 
 ;; eldoc
 (defun display-message-or-buffer-tostring (msg &rest _)
-  (let ((result (ocp-index-join-string msg)))
-    (if (string-match "No definition found\\|keyword\\.*" result)
-        ""
-      result)))
-
-(defun ocp-index-join-string (str)
-  (with-temp-buffer
-    (insert str)
-    (let ((fill-column 1000))
-      (fill-paragraph nil))
-    (buffer-string)))
+  (if (string-match "No definition found\\|keyword\\.*" msg)
+      ""
+    msg))
 
 (defun ocp-index-eldoc-function ()
   (condition-case nil


### PR DESCRIPTION
Following #101: 

- Don't turn `eldoc-mode` on by default, make it a customizable feature
- Make `eldoc` pretty printer behave exactly like a call to `ocp-index-print-info-at-point`
- Simplify some implementation hacks


Then:

- Add support for [ivy](https://github.com/abo-abo/swiper) completion backend