### PR TITLE
Small cleanup of code and ouput.

### DIFF
--- a/libs/jbuild
+++ b/libs/jbuild
@@ -8,4 +8,7 @@
                 compiler-libs.common
                 ocp-indent.lexer
                 ocp-indent.utils))
-  (wrapped     false)))
+  (wrapped     false)
+  (flags (:standard -w "-9"))
+))
+

--- a/ocp-index.opam
+++ b/ocp-index.opam
@@ -15,7 +15,7 @@ depends: [
   "ocp-pp"
   "jbuilder"
   "ocp-indent" {>= "1.4.2"}
-  "re"
+  "re" {>= "1.7.2"}
   "cmdliner"
 ]
 available: [ocaml-version >= "4.01.0" ]

--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -1,7 +1,6 @@
+open Lwt.Infix
 open Lwt_react
 open CamomileLibraryDyn.Camomile
-
-let (>>=) = Lwt.(>>=)
 
 (* LibIndex.info contains lazy values, we need a specialized equality. *)
 let rec eq l1 l2 = match l1, l2 with
@@ -173,6 +172,7 @@ let load_bindings () =
 
 
 (** Line editor *)
+
 (* Delicate mix between LTerm_read_line.engine and LTerm_edit.edit *)
 (* Should go into lambda-term. *)
 let newline = UChar.of_char '\n'
@@ -537,7 +537,7 @@ class completion_box options exit =
   end
 
 
-(** Count the size took by a text. *)
+(* Count the size took by a text. *)
 let size (str : LTerm_text.t) =
   let last = Array.length str - 1 in
   let rows = ref 0 in
@@ -556,7 +556,7 @@ let size (str : LTerm_text.t) =
   if fst str.(last) <> newline then incr rows ;
   {LTerm_geom. rows = !rows ; cols = !cols }
 
-(* * The show box shows the result of a research.
+(** The show box shows the result of a research.
 
     [content] is a list zipper positioned at the focused element.
     Left and right lists are elements before and after the focus.
@@ -713,13 +713,13 @@ class frame_info options = object
 end
 
 
-(** The list of non-modules kinds. *)
+(* The list of non-modules kinds. *)
 let value_kind_char_list = List.map UChar.of_char ['t';'e';'c';'k';'v']
 
-(** The list of modules kinds. *)
+(* The list of modules kinds. *)
 let modules_kind_char_list = List.map UChar.of_char ['m';'s']
 
-(** The list of all kinds. *)
+(* The list of all kinds. *)
 let kind_char_list = value_kind_char_list @ modules_kind_char_list
 
 let event_handler (cbox : #completion_box) (sbox:#show_box) options show_help =

--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -453,6 +453,18 @@ let index_of_biggest_prefix s l =
       end
   in loop 0 min_int None l
 
+(* Sort the list of completions. *)
+let sort_completion l =
+  let cmp
+      {LibIndex. file = f1; loc_impl = lazy {loc_start = l1}}
+      {LibIndex. file = f2; loc_impl = lazy {loc_start = l2}} =
+    let name_of_file (LibIndex.Cmi s | Cmt s | Cmti s) = s in
+    let i = String.compare (name_of_file f1) (name_of_file f2) in
+    if i <> 0 then i
+    else compare l1 l2
+  in
+  List.sort cmp l
+
 (** Mono line input with completion for a LibIndex.path. *)
 class completion_box options exit =
 
@@ -500,6 +512,7 @@ class completion_box options exit =
           options.IndexOptions.lib_info
           ~filter:(IndexOptions.filter options)
           (Zed_rope.to_string content)
+        |> sort_completion
       in
       set_completion_info response ;
       let completions =

--- a/src/grepMain.ml
+++ b/src/grepMain.ml
@@ -286,8 +286,8 @@ let grep_file finder color file =
 let grep pattern files color strings regexp =
   if strings || regexp then
     let re =
-      Re_posix.compile
-        (if regexp then Re_posix.re pattern else Re.str pattern)
+      Re.Posix.compile
+        (if regexp then Re.Posix.re pattern else Re.str pattern)
     in
     List.fold_left
       (fun found f -> grep_file (Grep.strings_re re) color f || found)

--- a/src/jbuild
+++ b/src/jbuild
@@ -4,7 +4,9 @@
  ((name        indexOptions)
   (modules     indexOptions)
   (libraries   (cmdliner ocp-index.lib))
-  (preprocess  (action (with-stdout-to ${@} (run ocp-pp ${<}))))))
+  (preprocess  (action (with-stdout-to ${@} (run ocp-pp ${<}))))
+  (flags (:standard -w "-9"))
+))
 
 (executable
  ((public_name ocp-index)
@@ -12,7 +14,9 @@
   (name        indexMain)
   (modules     indexMain)
   (preprocess  (action (with-stdout-to ${@} (run ocp-pp ${<}))))
-  (libraries   (unix ocp-index.lib cmdliner indexOptions))))
+  (libraries   (unix ocp-index.lib cmdliner indexOptions))
+  (flags (:standard -w "-9"))
+))
 
 (executable
  ((public_name ocp-grep)
@@ -20,7 +24,9 @@
   (name        grepMain)
   (modules     grepMain)
   (preprocess  (action (with-stdout-to ${@} (run ocp-pp ${<}))))
-  (libraries   (unix ocp-index.lib re re.posix cmdliner))))
+  (libraries   (unix ocp-index.lib re re.posix cmdliner))
+  (flags (:standard -w "-9"))
+))
 
 (executable
  ((public_name ocp-browser)
@@ -28,7 +34,9 @@
   (name        browserMain)
   (modules     browserMain)
   (preprocess  (action (with-stdout-to ${@} (run ocp-pp ${<}))))
-  (libraries   (unix lambda-term ocp-index.lib cmdliner indexOptions))))
+  (libraries   (unix lambda-term ocp-index.lib cmdliner indexOptions))
+  (flags (:standard -w "-9"))
+))
 
 (rule
  ((targets (ocp-index.1))

--- a/src/jbuild
+++ b/src/jbuild
@@ -34,7 +34,7 @@
   (name        browserMain)
   (modules     browserMain)
   (preprocess  (action (with-stdout-to ${@} (run ocp-pp ${<}))))
-  (libraries   (unix lambda-term ocp-index.lib cmdliner indexOptions))
+  (libraries   (unix re lambda-term ocp-index.lib cmdliner indexOptions))
   (flags (:standard -w "-9"))
 ))
 


### PR DESCRIPTION
This contains a small cleanup of the code to not be a warning-fest when using jbuilder.
I also took this ocasion to improve a bit the output by:

- Sorting the output according to 1) filename 2) position of the entry in the file
- Hiding modules of the form `Foo_bar` **only if `Foo` exists**.

I'm not very convinced by the first sorting methods, but we need something that is compatible with sorting by positions. The result is weird for toplevel modules, but rather good inside modules.