### PR TITLE
Add help hint

### DIFF
--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -881,6 +881,7 @@ let main options =
   let comp = new frame_info options in
   let input = new completion_box options exit in
   comp#set input ;
+  comp#set_label "Press alt+h for help" ;
   root#add ~expand:false comp ;
 
   let show_box = new show_box (colorise options) in


### PR DESCRIPTION
This adds a `Press alt+h for help` hint above the input box. It just sets the label on the frame which is perhaps not the nicest way semantically. I'm open for suggestions for how else to do it since I have not used lambda-term much.

I find that a lot of users are unaware of the full features of ocp-browser, especially that it can show documentation (and that there is a help menu showing this). I think adding this hint will help with discoverability.