### PR TITLE
Show documenation / extra info by default

### DIFF
--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -620,7 +620,7 @@ class show_box color = object (self)
   val mutable printed_entries = (0,0)
   method printed_entries = printed_entries
 
-  val mutable extra_info = false
+  val mutable extra_info = true
   method toogle_extra_info =
     extra_info <- not extra_info
 


### PR DESCRIPTION
Currently, the spacebar toggle-for-documentation is not very discoverable. Displaying documentation by default could help with this. Related to #119 

CC @c-cube