### PR TITLE
Fix lazy loading.

### DIFF
--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -473,12 +473,13 @@ let filter_completion l =
 (* Sort the list of completions. *)
 let sort_completion l =
   let cmp
-      {LibIndex. file = f1; loc_impl = lazy {loc_start = l1}}
-      {LibIndex. file = f2; loc_impl = lazy {loc_start = l2}} =
+      {LibIndex. file = f1; loc_impl = l1}
+      {LibIndex. file = f2; loc_impl = l2} =
     let name_of_file (LibIndex.Cmi s | Cmt s | Cmti s) = s in
     let i = String.compare (name_of_file f1) (name_of_file f2) in
     if i <> 0 then i
-    else compare l1 l2
+    else
+      compare (Lazy.force l1).loc_start (Lazy.force l2).loc_start
   in
   List.sort cmp l
 


### PR DESCRIPTION
It was all my fault :(

In c37c0bd7c1a9df385734ff1855fdf8756c7f82ea, the sneaky lazy pattern matching is far too eager to force things. This patch moves the forcing into the second branch, which brings back the loading time to instant.