### PR TITLE
[WIP] Add support for OCaml 4.10

### DIFF
--- a/libs/indexBuild.ml
+++ b/libs/indexBuild.ml
@@ -406,7 +406,11 @@ let trie_of_type_decl ?comments info ty_decl =
                 otype_type    = ty;
                 otype_private = Asttypes.Public;
   #if OCAML_VERSION >= "4.03"
+    #if OCAML_VERSION >= "4.10"
+                otype_immediate = Type_immediacy.Unknown;
+    #else
                 otype_immediate = false;
+    #endif
     #if OCAML_VERSION >= "4.04"
                 otype_unboxed = false;
     #endif
@@ -470,7 +474,11 @@ let trie_of_type_decl ?comments info ty_decl =
                 otype_type    = params;
                 otype_private = Asttypes.Public;
   #if OCAML_VERSION >= "4.03"
+    #if OCAML_VERSION >= "4.10"
+                otype_immediate = Type_immediacy.Unknown;
+    #else
                 otype_immediate = false;
+    #endif
     #if OCAML_VERSION >= "4.04"
                 otype_unboxed = false;
     #endif
@@ -582,7 +590,11 @@ let rec trie_of_sig_item
     | Types.Sig_module
 #if OCAML_VERSION >= "4.08"
         (id, presence,
+  #if OCAML_VERSION >= "4.10"
+         ({Types.md_type = Types.Mty_functor (_,s)} as funct),
+  #else
          ({Types.md_type = Types.Mty_functor (_,_,s)} as funct),
+  #endif
          is_rec, visibility)
       ->
         let funct = {funct with Types.md_type = s} in
@@ -597,7 +609,11 @@ let rec trie_of_sig_item
 #endif
     | Types.Sig_modtype
 #if OCAML_VERSION >= "4.08"
+  #if OCAML_VERSION >= "4.10"
+      (id, ({Types.mtd_type = Some (Types.Mty_functor (_,s))} as funct), visibility)
+  #else
       (id, ({Types.mtd_type = Some (Types.Mty_functor (_,_,s))} as funct), visibility)
+  #endif
       ->
         let funct = {funct with Types.mtd_type = Some s} in
         sig_item_contents (Types.Sig_modtype (id, funct, visibility))
@@ -703,7 +719,11 @@ let rec trie_of_sig_item
                     otype_type    = ty;
                     otype_private = Asttypes.Public;
   #if OCAML_VERSION >= "4.03"
+    #if OCAML_VERSION >= "4.10"
+                    otype_immediate = Type_immediacy.Unknown;
+    #else
                     otype_immediate = false;
+    #endif
     #if OCAML_VERSION >= "4.04"
                     otype_unboxed = false;
     #endif
@@ -748,7 +768,11 @@ let rec lookup_trie_of_module_expr parents t path = function
   | Typedtree.Tmod_constraint (e,_,_,_)
   (* | Typedtree.Tmod_apply (e,_,_) *) ->
       lookup_trie_of_module_expr parents t path e.mod_desc
+#if OCAML_VERSION >= "4.10"
+  | Typedtree.Tmod_apply ({ mod_desc = Typedtree.Tmod_functor(Typedtree.Named (Some id, _, _),f) },
+#else
   | Typedtree.Tmod_apply ({ mod_desc = Typedtree.Tmod_functor(id,_,_,f) },
+#endif
                           { mod_desc = Typedtree.Tmod_ident (arg,_)
                                      | Typedtree.Tmod_constraint ({mod_desc = Typedtree.Tmod_ident (arg,_)},_,_,_)  },_) ->
       let id_name = Ident.name id in
@@ -765,7 +789,11 @@ let rec extract_includes_from_submodule_sig parents t path name = function
           (Trie.sub t (modpath_to_key [name])) path sign
       ) in
       Trie.graft_lazy t (modpath_to_key [name]) sub_includes
+#if OCAML_VERSION >= "4.10"
+  | Typedtree.Tmty_functor (_,e)
+#else
   | Typedtree.Tmty_functor (_,_,_,e)
+#endif
   | Typedtree.Tmty_with (e,_) ->
       extract_includes_from_submodule_sig parents t path name e.Typedtree.mty_desc
   | _ -> t
@@ -779,7 +807,11 @@ and get_includes_impl parents t path ttree_struct =
         ) in
         Trie.graft_lazy t (modpath_to_key [name]) sub_includes
     (* | Typedtree.Tmod_functor (arg_id,_,arg_t,e) *)
+#if OCAML_VERSION >= "4.10"
+    | Typedtree.Tmod_apply ({ mod_desc = Typedtree.Tmod_functor(Typedtree.Named (Some id, _, _),f) },
+#else
     | Typedtree.Tmod_apply ({ mod_desc = Typedtree.Tmod_functor(id,_,_,f) },
+#endif
                             { mod_desc = Typedtree.Tmod_ident (arg,_)
                                        | Typedtree.Tmod_constraint ({mod_desc = Typedtree.Tmod_ident (arg,_)},_,_,_)  },_) ->
         let id_name = Ident.name id in
@@ -791,7 +823,11 @@ and get_includes_impl parents t path ttree_struct =
         extract_submodule_impl
           (Trie.graft_lazy t (modpath_to_key [id_name]) functor_arg)
           name f.Typedtree.mod_desc
+#if OCAML_VERSION >= "4.10"
+    | Typedtree.Tmod_functor (_,e)
+#else
     | Typedtree.Tmod_functor (_,_,_,e)
+#endif
     | Typedtree.Tmod_constraint (e,_,_,_) ->
         extract_submodule_impl t name e.Typedtree.mod_desc
     | _ -> t
@@ -818,11 +854,19 @@ and get_includes_impl parents t path ttree_struct =
           let sub = lookup_parents ((path, lazy t) :: parents) path (path_of_ocaml p) in
           overriding_merge t sub
       | Typedtree.Tstr_module
+#if OCAML_VERSION >= "4.10"
+          { Typedtree.mb_id = Some id; mb_expr = { Typedtree.mod_desc } } ->
+#else
           { Typedtree.mb_id = id; mb_expr = { Typedtree.mod_desc } } ->
+#endif
           extract_submodule_impl t (Ident.name id) mod_desc
       | Typedtree.Tstr_recmodule l ->
           List.fold_left
+#if OCAML_VERSION >= "4.10"
+            (fun t { Typedtree.mb_id = Some mb_id; mb_expr = { Typedtree.mod_desc } } ->
+#else
             (fun t { Typedtree.mb_id; mb_expr = { Typedtree.mod_desc } } ->
+#endif
                extract_submodule_impl t (Ident.name mb_id) mod_desc)
             t l
       | Typedtree.Tstr_modtype
@@ -851,14 +895,22 @@ and get_includes_sig parents t path ttree_sig =
           { Typedtree.incl_mod = { Typedtree.mty_desc = e }} ->
           extract_includes t e
       | Typedtree.Tsig_module
+#if OCAML_VERSION >= "4.10"
+          { Typedtree.md_id = Some id ; md_type = { Typedtree.mty_desc } }
+#else
           { Typedtree.md_id = id ; md_type = { Typedtree.mty_desc } }
+#endif
       | Typedtree.Tsig_modtype
           { Typedtree.mtd_id = id; mtd_type = Some { Typedtree.mty_desc } } ->
           extract_includes_from_submodule_sig parents t path
             (Ident.name id) mty_desc
       | Typedtree.Tsig_recmodule l ->
           List.fold_left
+#if OCAML_VERSION >= "4.10"
+            (fun t { Typedtree.md_id = Some md_id; md_type = { Typedtree.mty_desc } } ->
+#else
             (fun t { Typedtree.md_id; md_type = { Typedtree.mty_desc } } ->
+#endif
                extract_includes_from_submodule_sig parents t path
                  (Ident.name md_id) mty_desc)
             t l

--- a/libs/indexBuild.ml
+++ b/libs/indexBuild.ml
@@ -797,6 +797,11 @@ let rec extract_includes_from_submodule_sig parents t path name = function
   | Typedtree.Tmty_with (e,_) ->
       extract_includes_from_submodule_sig parents t path name e.Typedtree.mty_desc
   | _ -> t
+and extract_includes_from_submodule_sig_opt parents t path id mty =
+#if OCAML_VERSION >= "4.10"
+  match id with None -> t | Some id ->
+#endif
+    extract_includes_from_submodule_sig parents t path (Ident.name id) mty
 and get_includes_impl parents t path ttree_struct =
   let rec extract_submodule_impl t name = function
     | Typedtree.Tmod_structure str ->
@@ -832,6 +837,12 @@ and get_includes_impl parents t path ttree_struct =
         extract_submodule_impl t name e.Typedtree.mod_desc
     | _ -> t
   in
+  let extract_submodule_impl_opt t id mty =
+#if OCAML_VERSION >= "4.10"
+      match id with None -> t | Some id ->
+#endif
+        extract_submodule_impl t (Ident.name id) mty
+  in
   List.fold_left (fun t struc_item ->
       match struc_item.Typedtree.str_desc with
 #if OCAML_VERSION >= "4.08"
@@ -854,20 +865,12 @@ and get_includes_impl parents t path ttree_struct =
           let sub = lookup_parents ((path, lazy t) :: parents) path (path_of_ocaml p) in
           overriding_merge t sub
       | Typedtree.Tstr_module
-#if OCAML_VERSION >= "4.10"
-          { Typedtree.mb_id = Some id; mb_expr = { Typedtree.mod_desc } } ->
-#else
-          { Typedtree.mb_id = id; mb_expr = { Typedtree.mod_desc } } ->
-#endif
-          extract_submodule_impl t (Ident.name id) mod_desc
+          { Typedtree.mb_id; mb_expr = { Typedtree.mod_desc } } ->
+          extract_submodule_impl_opt t mb_id mod_desc
       | Typedtree.Tstr_recmodule l ->
           List.fold_left
-#if OCAML_VERSION >= "4.10"
-            (fun t { Typedtree.mb_id = Some mb_id; mb_expr = { Typedtree.mod_desc } } ->
-#else
             (fun t { Typedtree.mb_id; mb_expr = { Typedtree.mod_desc } } ->
-#endif
-               extract_submodule_impl t (Ident.name mb_id) mod_desc)
+               extract_submodule_impl_opt t mb_id mod_desc)
             t l
       | Typedtree.Tstr_modtype
           { Typedtree.mtd_id = id; mtd_type = Some { Typedtree.mty_desc = e } } ->
@@ -895,24 +898,18 @@ and get_includes_sig parents t path ttree_sig =
           { Typedtree.incl_mod = { Typedtree.mty_desc = e }} ->
           extract_includes t e
       | Typedtree.Tsig_module
-#if OCAML_VERSION >= "4.10"
-          { Typedtree.md_id = Some id ; md_type = { Typedtree.mty_desc } }
-#else
-          { Typedtree.md_id = id ; md_type = { Typedtree.mty_desc } }
-#endif
+          { Typedtree.md_id ; md_type = { Typedtree.mty_desc } } ->
+          extract_includes_from_submodule_sig_opt parents t path
+            md_id mty_desc
       | Typedtree.Tsig_modtype
           { Typedtree.mtd_id = id; mtd_type = Some { Typedtree.mty_desc } } ->
           extract_includes_from_submodule_sig parents t path
             (Ident.name id) mty_desc
       | Typedtree.Tsig_recmodule l ->
           List.fold_left
-#if OCAML_VERSION >= "4.10"
-            (fun t { Typedtree.md_id = Some md_id; md_type = { Typedtree.mty_desc } } ->
-#else
             (fun t { Typedtree.md_id; md_type = { Typedtree.mty_desc } } ->
-#endif
-               extract_includes_from_submodule_sig parents t path
-                 (Ident.name md_id) mty_desc)
+               extract_includes_from_submodule_sig_opt parents t path
+                 md_id mty_desc)
             t l
       | _ -> t)
     t ttree_sig.Typedtree.sig_items

--- a/libs/indexPredefined.ml
+++ b/libs/indexPredefined.ml
@@ -35,7 +35,11 @@ let mktype name ?(params=[]) ?(def=Otyp_abstract) doc = {
         otype_type    = def;
         otype_private = Asttypes.Public;
   #if OCAML_VERSION >= "4.03"
+    #if OCAML_VERSION >= "4.10"
+        otype_immediate = Type_immediacy.Unknown;
+    #else
         otype_immediate = false;
+    #endif
     #if OCAML_VERSION >= "4.04"
         otype_unboxed = false;
     #endif
@@ -59,7 +63,11 @@ let mkvariant name parent params = {
                                          | l  -> Otyp_tuple l);
         otype_private = Asttypes.Public;
   #if OCAML_VERSION >= "4.03"
+    #if OCAML_VERSION >= "4.10"
+        otype_immediate = Type_immediacy.Unknown;
+    #else
         otype_immediate = false ;
+    #endif
     #if OCAML_VERSION >= "4.04"
         otype_unboxed = false;
     #endif

--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -72,14 +72,22 @@ let load_style () =
     Lwt.return ()
     )
 
+#if OCAML_VERSION >= "4.08"
+let pp_open_tag fmt tag = Format.pp_open_stag fmt (Format.String_tag tag)
+let pp_close_tag = Format.pp_close_stag
+#else
+let pp_open_tag = Format.pp_open_tag
+let pp_close_tag = Format.pp_close_tag
+#endif
+
 (** Similar to {!LTerm_text.pp_with_style} but with no typing restriction. *)
 let pp_with_style to_style =
   fun style fstr fmt ->
     let tag = to_style style in
-    Format.pp_open_tag fmt tag;
+    pp_open_tag fmt tag;
     Format.kfprintf
       (fun fmt ->
-         Format.pp_close_tag fmt ())
+         pp_close_tag fmt ())
       fmt fstr
 
 let colorise opts =
@@ -719,9 +727,9 @@ let rec pp_print_list ?(pp_sep = Format.pp_print_cut) pp_v ppf = function
 let pp_kinds fmt options =
   let pp_kind fmt (c, hash, b) =
     if b then (
-      Format.pp_open_tag fmt "Enabled" ;
+      pp_open_tag fmt "Enabled" ;
       pp_with_style (fun x -> x) hash "%s" fmt c ;
-      Format.pp_close_tag fmt ()
+      pp_close_tag fmt ()
     ) else
       pp_with_style (fun x -> x) "Disabled" "%s" fmt c ;
   in


### PR DESCRIPTION
This PR aims to fix https://github.com/OCamlPro/ocp-index/issues/138. Both `ocp-index` and `ocp-browser` compiles with this branch, however as I don't understand the code completely I can't make claims on whether this works or not. Furthermore it introduces warnings/failures so it is not meant to be merged as is right now.

However, it can help you know what needs to be resolved before merging it and it allows me to have a version of `ocp-index` that compiles with OCaml 4.10 to be able to test packages that rely on it.

The main point of unknown for me in this code is: in `libs/indexBuild.ml`, what to do when module names/functor parameters are equal to `None`? Do they have to be discarded or is it to be included in the code?