### PR TITLE
Fix licenses

### DIFF
--- a/ocp-browser.opam
+++ b/ocp-browser.opam
@@ -12,7 +12,7 @@ authors: [
 ]
 homepage: "http://www.typerex.org/ocp-index.html"
 bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
-license: "LGPL-2.1 with OCaml linking exception"
+license: "GPL-3.0-only"
 tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]

--- a/ocp-index.opam
+++ b/ocp-index.opam
@@ -17,7 +17,7 @@ authors: [
 ]
 homepage: "http://www.typerex.org/ocp-index.html"
 bug-reports: "https://github.com/OCamlPro/ocp-index/issues"
-license: "LGPL-2.1 with OCaml linking exception"
+license: ["LGPL-2.1-only with OCaml-LGPL-linking-exception" "GPL-3.0-only"]
 tags: [ "org:ocamlpro" "org:typerex" ]
 dev-repo: "git+https://github.com/OCamlPro/ocp-index.git"
 build: ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
This makes ocp-index and ocp-browser pass opam lint