### PR TITLE
Avoid scanning directories starting with '_' or '.'

### DIFF
--- a/src/grepMain.ml
+++ b/src/grepMain.ml
@@ -162,9 +162,7 @@ module Args = struct
 
   let files_of_dir dirs =
     let skip d = match d.[0] with
-      | '_' -> true
-      | '.' -> d <> Filename.current_dir_name &&
-               d <> Filename.parent_dir_name
+      | '_' | '.' -> true
       | _ -> false
     in
     List.fold_left (fun acc dir ->

--- a/src/indexMain.ml
+++ b/src/indexMain.ml
@@ -253,7 +253,7 @@ let () =
     with
     | LibIndex.Bad_format f ->
         Printf.eprintf
-          "[ERROR] %S can't be read.\n\
+          "\r\027[K[ERROR] %S can't be read.\n\
            It's likely that it belongs to a version of OCaml different from \
            the one ocp-index was compiled against.\n"
           f;

--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -256,13 +256,22 @@ let common_opts ?(default_filter = default_filter) () : t Term.t =
          & info ["context"] ~docv:"FILEPOS" ~doc)
   in
   let lib_info ocamllib (_root,build) (opens,full_opens) context =
+    IndexMisc.debug "Using project root at %s\n\
+                    \      build dir at %s\n\
+                    \      libdir at %s\n"
+      (match _root with Some d -> d | None -> "<none>")
+      (match build with Some d -> d | None -> "<none>")
+      (String.concat ", " ocamllib);
     let dirs = match build with
       | None -> ocamllib
       | Some d -> d :: ocamllib
     in
     if dirs = [] then
       failwith "Failed to guess OCaml / opam lib dirs. Please use `-I'";
-    let dirs = LibIndex.Misc.unique_subdirs dirs in
+    let dirs =
+      let skip d = match d.[0] with '_' | '.' -> true | _ -> false in
+      LibIndex.Misc.unique_subdirs ~skip dirs
+    in
     let info = LibIndex.load dirs in
     let info = match context with
       | None -> info


### PR DESCRIPTION
They are unlikely to contain the expected artefacts, and `_build`, `_opam` etc.
are already detected specifically for build dir and libdir.

This can speedup lookups with local switches, avoid bad artifacts found in a
disabled local switch (eg `_opam.bak`), and preserve proper priorities for
similarly named modules.