### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name indexOptions)
  (modules indexOptions)
- (libraries cmdliner ocp-index.lib)
+ (libraries cmdliner ocp-index.lib unix)
  (preprocess
   (action
    (run %{bin:cppo} -V OCAML:%{ocaml_version} %{input-file})))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.