### PR TITLE
Windows fixes + OCAMLPATH compatibility

### DIFF
--- a/src/indexOptions.ml
+++ b/src/indexOptions.ml
@@ -46,9 +46,11 @@ let filter opt info =
   | ModuleType | ClassType -> kinds.s
   | Keyword -> kinds.k
 
+let null_file = if Sys.win32 then "NUL" else "/dev/null"
+
 let cmd_input_line cmd =
   try
-    let ic = Unix.open_process_in (cmd ^ " 2>/dev/null") in
+    let ic = Unix.open_process_in (Printf.sprintf "%s 2>%s" cmd null_file) in
     let r = input_line ic in
     let r =
       let len = String.length r in


### PR DESCRIPTION
- The first commit is needed for Windows compatibility.
- The second commit makes `ocp-index` honour the `OCAMLPATH` environment variable (used by Dune, `ocamlfind`, etc) which is useful in non-OPAM contexts.

Let me know what you think! Thanks.