### PR TITLE
Handle cmdliner deprecation and support for cmdliner 2.0

### DIFF
--- a/ocp-browser.opam
+++ b/ocp-browser.opam
@@ -21,7 +21,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "dune" {>= "1.0"}
   "ocp-index" {= version}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.3.0"}
   "lambda-term" {>= "3.3.0"}
   "zed" {>= "2.0.0"}
   "odoc" {with-test}

--- a/ocp-index.opam
+++ b/ocp-index.opam
@@ -28,7 +28,7 @@ depends: [
   "dune" {>= "1.0"}
   "ocp-indent" {>= "1.4.2"}
   "re" {>= "1.9.0"}
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "1.3.0"}
   "odoc" {with-doc}
 ]
 post-messages:

--- a/src/browserMain.ml
+++ b/src/browserMain.ml
@@ -916,17 +916,19 @@ let run options () =
     fun () -> main options
   )
 
-let main_term : unit Cmdliner.Term.t * Cmdliner.Term.info =
+let main_term : unit Cmdliner.Cmd.t =
   let open Cmdliner in
   let doc = "Interactively completes and prints documentation." in
   let man = [`S "DESCRIPTION"; `P "See alt+h for help."] in
-  Term.(pure run
+  let version = Ocp_browser_version.version in
+  Cmd.v (Cmd.info "ocp-browser" ~version ~doc ~man) @@
+  Term.(const run
         $ IndexOptions.common_opts ~default_filter:[`T;`V;`E;`C;`M;`S;`K] ()
-        $ pure ()),
-  Term.info "ocp-browser" ~version:(Ocp_browser_version.version) ~doc ~man
+        $ const ())
+
 
 let () =
-  match Cmdliner.Term.eval main_term
+  match Cmdliner.Cmd.eval_value main_term
   with
-  | `Error _ -> exit 1
-  | _ -> exit 0
+  | Error _ -> exit 1
+  | Ok _ -> exit 0


### PR DESCRIPTION
This PR handles the deprecations of cmdliner and make it depend on cmdliner 1.3.0.

This means that ocp-index will work with the upcoming cmdliner 2.0 where a type becomes abstract and deprecated interfaces are removed. See https://github.com/dbuenzli/cmdliner/issues/206